### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -457,3 +457,6 @@ launchSettings.json
 dist/
 data/**
 !data/.gitkeep
+
+## Mac specific
+.DS_Store


### PR DESCRIPTION
Navigating to a folder using the "Finder" on Mac generates a .DS_Store file holding metadata about the folder (e.g. thumbnails etc.). These files can pollute your git commits and are annoying.